### PR TITLE
Added parameters to sendRequest

### DIFF
--- a/classes/PhFacebook.h
+++ b/classes/PhFacebook.h
@@ -31,7 +31,7 @@
 // request: the short version of the Facebook Graph API, e.g. "me/feed"
 // see http://developers.facebook.com/docs/api
 - (void) sendRequest: (NSString*) request;
-- (void) sendRequest: (NSString*) request params:(NSDictionary *)params;
+- (void) sendRequest: (NSString*) request params: (NSDictionary*) params;
 
 
 - (void) setAccessToken: (NSString*) accessToken expires: (NSTimeInterval) tokenExpires permissions: (NSString*) perms error: (NSString*) errorReason;

--- a/classes/PhFacebook.m
+++ b/classes/PhFacebook.m
@@ -145,21 +145,21 @@
 	[self notifyDelegateForToken: _authToken withError: errorReason];
 }
 
-- (void)sendFacebookRequest:(NSDictionary *)allParams
+- (void) sendFacebookRequest: (NSDictionary*) allParams
 {
     NSAutoreleasePool *pool = [NSAutoreleasePool new];
 
     if (_authToken)
     {
-        NSString *request = [allParams objectForKey:@"request"];
+        NSString *request = [allParams objectForKey: @"request"];
         NSString *str = [NSString stringWithFormat: kFBGraphApiURL, request, _authToken.authenticationToken];
         
         NSDictionary *params = [allParams objectForKey:@"params"];
-        if (params != nil) {
-            NSMutableString *strWithParams = [NSMutableString stringWithString:str];
-            for (NSString *p in [params allKeys]) {
-                [strWithParams appendFormat:@"&%@=%@", p, [params objectForKey:p]];
-            }
+        if (params != nil) 
+        {
+            NSMutableString *strWithParams = [NSMutableString stringWithString: str];
+            for (NSString *p in [params allKeys]) 
+                [strWithParams appendFormat: @"&%@=%@", p, [params objectForKey: p]];
             str = strWithParams;
         }
         
@@ -184,18 +184,18 @@
     [pool drain];
 }
 
-- (void)sendRequest:(NSString *)request params:(NSDictionary *)params;
+- (void) sendRequest: (NSString*) request params: (NSDictionary*) params;
 {
-    NSMutableDictionary *allParams = [NSMutableDictionary dictionaryWithObject:request forKey:@"request"];
+    NSMutableDictionary *allParams = [NSMutableDictionary dictionaryWithObject: request forKey: @"request"];
     if (params != nil)
-        [allParams setObject:params forKey:@"params"];
+        [allParams setObject: params forKey: @"params"];
 
-	[NSThread detachNewThreadSelector:@selector(sendFacebookRequest:) toTarget:self withObject:allParams];    
+	[NSThread detachNewThreadSelector: @selector(sendFacebookRequest:) toTarget: self withObject: allParams];    
 }
 
 - (void) sendRequest: (NSString*) request
 {
-    [self sendRequest:request params:nil];
+    [self sendRequest: request params: nil];
 }
 
 #pragma mark Notifications


### PR DESCRIPTION
Hi Phillip,

I needed to include some parameters to my friends request so I added a sendRequest:parameters method, changed sendRequest: to call sendRequest:parameters: and changed sendFacebookRequest: to use the parameters.

I think it would make a good addition as I'm sure others need to send parameters as well. I'm surprised it wasn't already there.
