### PR TITLE
Support custom authentication UI

### DIFF
--- a/classes/PhFacebook.h
+++ b/classes/PhFacebook.h
@@ -14,11 +14,11 @@
 @interface PhFacebook : NSObject
 {
 @private
-    NSString *_appID;
-    id _delegate;
-    PhWebViewController *_webViewController;
-    PhAuthenticationToken *_authToken;
-    NSString *_permissions;
+  NSString *_appID;
+  id _delegate;
+  PhWebViewController *_webViewController;
+  PhAuthenticationToken *_authToken;
+  NSString *_permissions;
 }
 
 - (id) initWithApplicationID: (NSString*) appID delegate: (id) delegate;
@@ -33,6 +33,7 @@
 - (void) sendRequest: (NSString*) request;
 - (void) sendRequest: (NSString*) request params: (NSDictionary*) params usePostRequest: (BOOL) postRequest;
 
+- (void) invalidateCachedToken;
 
 - (void) setAccessToken: (NSString*) accessToken expires: (NSTimeInterval) tokenExpires permissions: (NSString*) perms error: (NSString*) errorReason;
 - (NSString*) accessToken;
@@ -49,6 +50,10 @@
 - (void) requestResult: (NSDictionary*) result;
 
 @optional
+// needAuth is called before showing authentication WebView
+// if it returns true, default login window will not be shown and
+// application is responsible for authentication UI
+- (BOOL) needAuth:(NSString*)authURL forPermissions:(NSString *)permissions; 
 - (void) willShowUINotification: (PhFacebook*) sender;
 - (void) didDismissUI: (PhFacebook*) sender;
 

--- a/classes/PhFacebook.m
+++ b/classes/PhFacebook.m
@@ -78,6 +78,15 @@
     _authToken = nil;
 }
 
+-(void)invalidateCachedToken
+{
+    [self clearToken];
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults removeObjectForKey:kFBStoreAccessToken];
+    [defaults removeObjectForKey: kFBStoreTokenExpiry];
+    [defaults removeObjectForKey: kFBStoreAccessPermissions];
+}
+
 - (void) setAccessToken: (NSString*) accessToken expires: (NSTimeInterval) tokenExpires permissions: (NSString*) perms
 {
     [self clearToken];
@@ -125,7 +134,14 @@
             authURL = [NSString stringWithFormat: kFBAuthorizeWithScopeURL, _appID, kFBLoginSuccessURL, scope];
         else
             authURL = [NSString stringWithFormat: kFBAuthorizeURL, _appID, kFBLoginSuccessURL];
-
+      
+        if ([_delegate respondsToSelector: @selector(tokenResult:)]) {
+          if ([_delegate needAuth:authURL forPermissions:scope]) {
+            // if needAuth returns true, we will let delegate handle the auth UI
+            return;
+          }
+        }
+      
         // Retrieve token from web page
         if (_webViewController == nil)
         {


### PR DESCRIPTION
The default auth UI in a dedicated window is a nice shortcut, however sometimes it might be desirable to integrated WebView into another window. 

This patch adds a new optional method to PhFacebookDelegate:
```- (BOOL) needAuth:(NSString*)authURL forPermissions:(NSString *)permissions; 

```

If this method is implemented and returns true, PhFacebook will not display authentication window, instead it will rely on delegate to display appropriate URLs to user and perform necessary callbacks similarly to PhWebViewController.

As a bonus also added invalidateCachedToken which removes cached tokens from user defaults.
```
