### PR TITLE
If an expired cached token is initialized, expiration time is ignored

### DIFF
--- a/classes/PhAuthenticationToken.m
+++ b/classes/PhAuthenticationToken.m
@@ -17,7 +17,8 @@
 
 - (id) initWithToken: (NSString*) token secondsToExpiry: (NSTimeInterval) seconds permissions: (NSString*) perms
 {
-    if ((self == [super init]))
+    
+    if ((self = [super init]))
     {
         self.authenticationToken = token;
         if (seconds != 0)

--- a/classes/PhFacebook.m
+++ b/classes/PhFacebook.m
@@ -22,7 +22,7 @@
 
 - (id) initWithApplicationID: (NSString*) appID delegate: (id) delegate
 {
-    if ((self == [super init]))
+    if ((self = [super init]))
     {
         if (appID)
             _appID = [[NSString stringWithString: appID] retain];


### PR DESCRIPTION
PhAuthenticationToken init method was setting token's expiry date to nil if secondsToExpiry was negative.

However PhFacebook.m is assuming that token is valid when expiry is nil:

```
if (_authToken.expiry == nil || [[_authToken.expiry laterDate: [NSDate date]] isEqual: _authToken.expiry])
    validToken = YES;
```
