### PR TITLE
Anything but succesful grabbing of the access token should result in the 

### DIFF
--- a/private/PhFacebook_URLs.h
+++ b/private/PhFacebook_URLs.h
@@ -13,7 +13,6 @@
 
 #define kFBAuthorizeWithScopeURL @"https://graph.facebook.com/oauth/authorize?client_id=%@&redirect_uri=%@&scope=%@&type=user_agent&display=popup"
 
-#define kFBLoginURL @"https://www.facebook.com/login.php"
 #define kFBLoginSuccessURL @"http://www.facebook.com/connect/login_success.html"
 
 #define kFBUIServerURL @"http://www.facebook.com/connect/uiserver.php"


### PR DESCRIPTION
Anything but succesful grabbing of the access token should result in the UI opening. Before the UI
     would only open if the url of the frame was found to be a login page. That did not take into account 
     when the user is already logged into facebook in the browser, but has yet to authorize the application.
     In that case, the ui would not open and the user could never authorize... this fixes that.
